### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # 𝔣𝔯𝔞𝔨𝔱𝔲𝔯
 
-[![PyPi version](https://pypip.in/v/fraktur/badge.png?style=flat)](https://pypi.python.org/pypi/fraktur)
-[![PyPi downloads](https://pypip.in/d/fraktur/badge.png?style=flat)](https://pypi.python.org/pypi/fraktur)
-[![PyPi status](https://pypip.in/status/fraktur/badge.svg?style=flat)](https://pypi.python.org/pypi/fraktur)
-[![PyPi license](https://pypip.in/license/fraktur/badge.svg?style=flat)](https://pypi.python.org/pypi/fraktur)
+[![PyPi version](https://img.shields.io/pypi/v/fraktur.svg?style=flat)](https://pypi.python.org/pypi/fraktur)
+[![PyPi downloads](https://img.shields.io/pypi/dm/fraktur.svg?style=flat)](https://pypi.python.org/pypi/fraktur)
+[![PyPi status](https://img.shields.io/pypi/status/fraktur.svg?style=flat)](https://pypi.python.org/pypi/fraktur)
+[![PyPi license](https://img.shields.io/pypi/l/fraktur.svg?style=flat)](https://pypi.python.org/pypi/fraktur)
 
 𝔠𝔬𝔫𝔳𝔢𝔯𝔱 𝔱𝔥𝔢 𝔩𝔞𝔱𝔦𝔫 𝔞𝔩𝔭𝔥𝔞𝔟𝔢𝔱 𝔱𝔬
 [𝔣𝔯𝔞𝔨𝔱𝔲𝔯 𝔲𝔫𝔦𝔠𝔬𝔡𝔢 𝔠𝔥𝔞𝔯𝔞𝔠𝔱𝔢𝔯𝔰](http://www.fileformat.info/info/unicode/char/search.htm?q=fraktur&preview=entity)


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20fraktur))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `fraktur`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.